### PR TITLE
Added backup timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.1.2
+
+Added `backup_timeout` parameter to all actions to control the timeout of the long-running
+backup commands within the workflows (`mongodump`, `pg_dump`, `tar`, etc).
+
 ## v0.1.1
 
 Added pack icon. No code changes.

--- a/actions/full_backup.yaml
+++ b/actions/full_backup.yaml
@@ -23,4 +23,7 @@ parameters:
     type: string
     description: "Passed into the find command. Deletes files based on this value. To find files older than n days it should be +n . If you specify just n it will find files that are exactly n days old."
     default: "{{ st2kv.system.backup.retention_days | string | default('+14', true) }}"
+  backup_timeout:
+    type: integer
+    default: 600
     

--- a/actions/mongodb_backup.yaml
+++ b/actions/mongodb_backup.yaml
@@ -22,3 +22,6 @@ parameters:
     type: string
     description: "Passed into the find command. Deletes files based on this value. To find files older than n days it should be +n . If you specify just n it will find files that are exactly n days old."
     default: "{{ st2kv.system.backup.retention_days | string | default('+14', true) }}"
+  backup_timeout:
+    type: integer
+    default: 600

--- a/actions/postgres_backup.yaml
+++ b/actions/postgres_backup.yaml
@@ -18,3 +18,6 @@ parameters:
     type: string
     description: "Passed into the find command. Deletes files based on this value. To find files older than n days it should be +n . If you specify just n it will find files that are exactly n days old."
     default: "{{ st2kv.system.backup.retention_days | string | default('+14', true) }}"
+  backup_timeout:
+    type: integer
+    default: 600

--- a/actions/workflows/full_backup.yaml
+++ b/actions/workflows/full_backup.yaml
@@ -9,6 +9,7 @@ backups.full_backup:
     - mongodb_admin_username
     - mongodb_admin_password
     - retention_days
+    - backup_timeout
 
   output:
     mongodb_dump_archive: "{{ _.mongodb_dump_archive }}"
@@ -34,6 +35,7 @@ backups.full_backup:
         mongodb_admin_username: "{{ _.mongodb_admin_username }}"
         mongodb_admin_password: "{{ _.mongodb_admin_password }}"
         retention_days: "{{ _.retention_days }}"
+        backup_timeout: "{{ _.backup_timeout }}"
       publish:
         mongodb_dump_archive: "{{ task('mongodb_backup').result.mongodb_dump_archive }}"
       on-success:
@@ -46,6 +48,7 @@ backups.full_backup:
         date: "{{ _.date }}"
         mistral_config: "{{ _.mistral_config }}"
         retention_days: "{{ _.retention_days }}"
+        backup_timeout: "{{ _.backup_timeout }}"
       publish:
         postgres_dump_archive: "{{ task('postgres_backup').result.postgres_dump_archive }}"
       on-success:

--- a/actions/workflows/mongodb_backup.yaml
+++ b/actions/workflows/mongodb_backup.yaml
@@ -9,6 +9,7 @@ backups.mongodb_backup:
     - mongodb_admin_username
     - mongodb_admin_password: "{{ st2kv('system.mongodb.admin_password', decrypt=True) }}"
     - retention_days
+    - backup_timeout
     
   output:
     mongodb_dump_archive: "{{ _.mongodb_dump_archive }}"
@@ -51,6 +52,7 @@ backups.mongodb_backup:
       input:
         cwd: "{{ _.path }}"
         cmd: "mongodump -o '{{ _.mongodb_dump_dirname }}'"
+        timeout: "{{ _.backup_timeout }}"
       on-success:
         - mongodb_compress
 
@@ -59,6 +61,7 @@ backups.mongodb_backup:
       input:
         cwd: "{{ _.path }}"
         cmd: "mongodump -u '{{ _.mongodb_admin_username }}' -p '{{ _.mongodb_admin_password }}' -o '{{ _.mongodb_dump_dirname }}'"
+        timeout: "{{ _.backup_timeout }}"
       on-success:
         - mongodb_compress
 
@@ -67,6 +70,7 @@ backups.mongodb_backup:
       input:
         cwd: "{{ _.path }}"
         cmd: "tar --remove-files -zcf {{ _.mongodb_dump_dirname }}.tar.gz {{ _.mongodb_dump_dirname }}"
+        timeout: "{{ _.backup_timeout }}"
       on-success:
         - mongodb_delete_old_files
 

--- a/actions/workflows/postgres_backup.yaml
+++ b/actions/workflows/postgres_backup.yaml
@@ -8,6 +8,7 @@ backups.postgres_backup:
     - mistral_config
     - date
     - retention_days
+    - backup_timeout
     
   output:
     postgres_dump_archive: "{{ _.postgres_dump_archive }}"
@@ -51,6 +52,7 @@ backups.postgres_backup:
       action: core.local_sudo
       input:
         cmd: "pg_dump -f '{{ _.postgres_dump_file }}' '{{ _.postgres_connection }}'"
+        timeout: "{{ _.backup_timeout }}"
       on-success:
         - postgres_compress
 
@@ -58,6 +60,7 @@ backups.postgres_backup:
       action: core.local_sudo
       input:
         cmd: "gzip '{{ _.postgres_dump_file }}'"
+        timeout: "{{ _.backup_timeout }}"
       on-success:
         - postgres_delete_old_files
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
     - postgresql
     - mongo
     - mongodb
-version: 0.1.1
+version: 0.1.2
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION

Added `backup_timeout` parameter to all actions to control the timeout of the long-running
backup commands within the workflows (`mongodump`, `pg_dump`, `tar`, etc).