### PR TITLE
Convert mistral -> orquesta

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,26 @@
 # Change Log
 
+## v1.0.0
+
+* Migrated from Mistral -> Orquesta (Feature)
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
+* Added compression-in-place instead of dumping to a file/directory then running gzip.
+  This reduces the required disk space to execute backups, because we don't have to store
+  the intermediate uncompress data. (Feature)
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+
+* Added `--quiet` to the `mongodump` command, so that progress bars don't litter the `stdout`
+  of the action execution. (Bugfix)
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+
 ## v0.1.1
 
-Added pack icon. No code changes.
+* Added pack icon. No code changes.
 
 ## v0.1.0
 
-Initial Revision
+* Initial Revision

--- a/actions/full_backup.yaml
+++ b/actions/full_backup.yaml
@@ -1,7 +1,7 @@
 ---
 description: Performs a back of StackStorm MongoDB and Postgres databases
 enabled: true
-runner_type: mistral-v2
+runner_type: orquesta
 entry_point: workflows/full_backup.yaml
 name: full_backup
 pack: backups

--- a/actions/mongodb_backup.yaml
+++ b/actions/mongodb_backup.yaml
@@ -1,7 +1,7 @@
 ---
 description: Performs a back of StackStorm MongoDB database
 enabled: true
-runner_type: mistral-v2
+runner_type: orquesta
 entry_point: workflows/mongodb_backup.yaml
 name: mongodb_backup
 pack: backups
@@ -18,6 +18,10 @@ parameters:
     default: "{% set pw = st2kv.system.mongodb.admin_password | string %}{{ pw | decrypt_kv if pw else '' }}"
     type: string
     secret: true
+  mongodump_timeout:
+    default: "{% set timeout = st2kv.system.mongodb.dump_timeout | string %}{{ (timeout | int) if timeout else 600 }}"
+    type: integer
+    description: "Timeout, in seconds, for the mongodump command"
   retention_days:
     type: string
     description: "Passed into the find command. Deletes files based on this value. To find files older than n days it should be +n . If you specify just n it will find files that are exactly n days old."

--- a/actions/mongodb_backup.yaml
+++ b/actions/mongodb_backup.yaml
@@ -18,10 +18,6 @@ parameters:
     default: "{% set pw = st2kv.system.mongodb.admin_password | string %}{{ pw | decrypt_kv if pw else '' }}"
     type: string
     secret: true
-  mongodump_timeout:
-    default: "{% set timeout = st2kv.system.mongodb.dump_timeout | string %}{{ (timeout | int) if timeout else 600 }}"
-    type: integer
-    description: "Timeout, in seconds, for the mongodump command"
   retention_days:
     type: string
     description: "Passed into the find command. Deletes files based on this value. To find files older than n days it should be +n . If you specify just n it will find files that are exactly n days old."

--- a/actions/postgres_backup.yaml
+++ b/actions/postgres_backup.yaml
@@ -1,7 +1,7 @@
 ---
 description: Performs a back of StackStorm Postgres database
 enabled: true
-runner_type: mistral-v2
+runner_type: orquesta
 entry_point: workflows/postgres_backup.yaml
 name: postgres_backup
 pack: backups

--- a/actions/workflows/full_backup.yaml
+++ b/actions/workflows/full_backup.yaml
@@ -34,8 +34,7 @@ tasks:
       mongodb_admin_password: '{{ ctx().mongodb_admin_password }}'
       retention_days: '{{ ctx().retention_days }}'
     next:
-      - when: '{{ succeeded() or failed() }}'
-        publish:
+      - publish:
           - mongodb_dump_archive: '{{ result().output.mongodb_dump_archive }}'
         do:
           - end
@@ -48,8 +47,7 @@ tasks:
       mistral_config: '{{ ctx().mistral_config }}'
       retention_days: '{{ ctx().retention_days }}'
     next:
-      - when: '{{ succeeded() or failed() }}'
-        publish:
+      - publish:
           - postgres_dump_archive: '{{ result().output.postgres_dump_archive }}'
         do:
           - end

--- a/actions/workflows/full_backup.yaml
+++ b/actions/workflows/full_backup.yaml
@@ -1,56 +1,59 @@
-version: '2.0'
+---
+version: '1.0'
+description: Workflow that backs up the StackStorm MongoDB and Postgres databases
+input:
+  - path
+  - mistral_config
+  - mongodb_admin_username
+  - mongodb_admin_password
+  - retention_days
 
-backups.full_backup:
-  description: "Workflow that backs up the StackStorm MongoDB and Postgres databases"
-  type: direct
-  input:
-    - path
-    - mistral_config
-    - mongodb_admin_username
-    - mongodb_admin_password
-    - retention_days
+output:
+  - mongodb_dump_archive: '{{ ctx().mongodb_dump_archive }}'
+  - postgres_dump_archive: '{{ ctx().postgres_dump_archive }}'
 
-  output:
-    mongodb_dump_archive: "{{ _.mongodb_dump_archive }}"
-    postgres_dump_archive: "{{ _.postgres_dump_archive }}"
+tasks:
+  date:
+    action: core.local
+    input:
+      cmd: "date +%Y%m%d_%H%M%S"
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - date: '{{ result().stdout }}'
+        do:
+          - mongodb_backup
+          - postgres_backup
 
-  tasks:
+  mongodb_backup:
+    action: backups.mongodb_backup
+    input:
+      path: '{{ ctx().path }}'
+      date: '{{ ctx().date }}'
+      mongodb_admin_username: '{{ ctx().mongodb_admin_username }}'
+      mongodb_admin_password: '{{ ctx().mongodb_admin_password }}'
+      retention_days: '{{ ctx().retention_days }}'
+    next:
+      - when: '{{ succeeded() or failed() }}'
+        publish:
+          - mongodb_dump_archive: '{{ result().output.mongodb_dump_archive }}'
+        do:
+          - end
 
-    date:
-      action: core.local
-      input:
-        cmd: "date +%Y%m%d_%H%M%S"
-      publish:
-        date: "{{ task('date').result.stdout }}"
-      on-success:
-        - mongodb_backup
-        - postgres_backup
+  postgres_backup:
+    action: backups.postgres_backup
+    input:
+      path: '{{ ctx().path }}'
+      date: '{{ ctx().date }}'
+      mistral_config: '{{ ctx().mistral_config }}'
+      retention_days: '{{ ctx().retention_days }}'
+    next:
+      - when: '{{ succeeded() or failed() }}'
+        publish:
+          - postgres_dump_archive: '{{ result().output.postgres_dump_archive }}'
+        do:
+          - end
 
-    mongodb_backup:
-      action: backups.mongodb_backup
-      input:
-        path: "{{ _.path }}"
-        date: "{{ _.date }}"
-        mongodb_admin_username: "{{ _.mongodb_admin_username }}"
-        mongodb_admin_password: "{{ _.mongodb_admin_password }}"
-        retention_days: "{{ _.retention_days }}"
-      publish:
-        mongodb_dump_archive: "{{ task('mongodb_backup').result.mongodb_dump_archive }}"
-      on-success:
-        - end
-
-    postgres_backup:
-      action: backups.postgres_backup
-      input:
-        path: "{{ _.path }}"
-        date: "{{ _.date }}"
-        mistral_config: "{{ _.mistral_config }}"
-        retention_days: "{{ _.retention_days }}"
-      publish:
-        postgres_dump_archive: "{{ task('postgres_backup').result.postgres_dump_archive }}"
-      on-success:
-        - end
-
-    end:
-      action: std.noop
-      join: all
+  end:
+    action: core.noop
+    join: all

--- a/actions/workflows/mongodb_backup.yaml
+++ b/actions/workflows/mongodb_backup.yaml
@@ -1,78 +1,84 @@
-version: '2.0'
+---
+version: '1.0'
+description: Workflow that backs up the StackStorm MongoDB database
+input:
+  - path
+  - date
+  - mongodb_admin_username
+  - mongodb_admin_password: "{{ st2kv('system.mongodb.admin_password', decrypt=True) }}"
+  - mongodump_timeout
+  - retention_days
 
-backups.mongodb_backup:
-  description: "Workflow that backs up the StackStorm MongoDB database"
-  type: direct
-  input:
-    - path
-    - date
-    - mongodb_admin_username
-    - mongodb_admin_password: "{{ st2kv('system.mongodb.admin_password', decrypt=True) }}"
-    - retention_days
-    
-  output:
-    mongodb_dump_archive: "{{ _.mongodb_dump_archive }}"
-    
-  tasks:
-    
-    main:
-      action: std.noop
-      on-success:
-        - init: "{{ _.date }}"
-        - date: "{{ not _.date }}"
+output:
+  - mongodb_dump_archive: '{{ ctx().mongodb_dump_archive }}'
 
-    date:
-      action: core.local
-      input:
-        cmd: "date +%Y%m%d_%H%M%S"
-      publish:
-        date: "{{ task('date').result.stdout }}"
-      on-success:
-        - init
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() and (ctx().date) }}'
+        do:
+          - init
+      - when: '{{ succeeded() and (not ctx().date) }}'
+        do:
+          - date
 
-    init:
-      action: std.noop
-      publish:
-        mongodb_dump_dirname: "mongodb_dump_{{ _.date }}"
-        mongodb_dump_archive: "{{ _.path }}/mongodb_dump_{{ _.date }}.tar.gz"
-      on-success:
-        - mkdir_path
+  date:
+    action: core.local
+    input:
+      cmd: "date +%Y%m%d_%H%M%S"
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - date: '{{ result().stdout }}'
+        do:
+          - init
 
-    mkdir_path:
-      action: core.local_sudo
-      input:
-        cmd: "mkdir -p '{{ _.path }}'"
-      on-success:
-        - mongodb_backup: "{{ not _.mongodb_admin_username or not _.mongodb_admin_password }}"
-        - mongodb_backup_with_auth: "{{ _.mongodb_admin_username and _.mongodb_admin_password }}"
+  init:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - mongodb_dump_archive: '{{ ctx().path }}/mongodb_dump_{{ ctx().date }}.gzip.archive'
+        do:
+          - mkdir_path
 
-    mongodb_backup:
-      action: core.local_sudo
-      input:
-        cwd: "{{ _.path }}"
-        cmd: "mongodump -o '{{ _.mongodb_dump_dirname }}'"
-      on-success:
-        - mongodb_compress
+  mkdir_path:
+    action: core.local_sudo
+    input:
+      cmd: "mkdir -p '{{ ctx().path }}'"
+    next:
+      - when: '{{ succeeded() and (not ctx().mongodb_admin_username or not ctx().mongodb_admin_password) }}'
+        do:
+          - mongodb_backup
+      - when: '{{ succeeded() and (ctx().mongodb_admin_username and ctx().mongodb_admin_password) }}'
+        do:
+          - mongodb_backup_with_auth
 
-    mongodb_backup_with_auth:
-      action: core.local_sudo
-      input:
-        cwd: "{{ _.path }}"
-        cmd: "mongodump -u '{{ _.mongodb_admin_username }}' -p '{{ _.mongodb_admin_password }}' -o '{{ _.mongodb_dump_dirname }}'"
-      on-success:
-        - mongodb_compress
+  mongodb_backup:
+    action: core.local_sudo
+    input:
+      cwd: '{{ ctx().path }}'
+      cmd: "mongodump --quiet --gzip --archive='{{ ctx().mongodb_dump_archive }}'"
+      timeout: "{{ ctx().mongodump_timeout }}"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - mongodb_delete_old_files
 
-    mongodb_compress:
-      action: core.local_sudo
-      input:
-        cwd: "{{ _.path }}"
-        cmd: "tar --remove-files -zcf {{ _.mongodb_dump_dirname }}.tar.gz {{ _.mongodb_dump_dirname }}"
-      on-success:
-        - mongodb_delete_old_files
+  mongodb_backup_with_auth:
+    action: core.local_sudo
+    input:
+      cwd: '{{ ctx().path }}'
+      cmd: "mongodump -u '{{ ctx().mongodb_admin_username }}' -p '{{ ctx().mongodb_admin_password }}' --quiet --gzip --archive='{{ ctx().mongodb_dump_archive }}'"
+      timeout: "{{ ctx().mongodump_timeout }}"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - mongodb_delete_old_files
 
-    mongodb_delete_old_files:
-      action: core.local_sudo
-      input:
-        cwd: "{{ _.path }}"
-        cmd: "find . -name 'mongodb_dump_*' -mtime {{ _.retention_days }} | xargs --no-run-if-empty rm"
-      
+  mongodb_delete_old_files:
+    action: core.local_sudo
+    input:
+      cwd: '{{ ctx().path }}'
+      cmd: "find . -name 'mongodb_dump_*' -mtime {{ ctx().retention_days }} | xargs --no-run-if-empty rm"

--- a/actions/workflows/postgres_backup.yaml
+++ b/actions/workflows/postgres_backup.yaml
@@ -1,69 +1,69 @@
-version: '2.0'
+---
+version: '1.0'
+description: Workflow that backs up the StackStorm Postgres database
+input:
+  - path
+  - mistral_config
+  - date
+  - retention_days
 
-backups.postgres_backup:
-  description: "Workflow that backs up the StackStorm Postgres database"
-  type: direct
-  input:
-    - path
-    - mistral_config
-    - date
-    - retention_days
-    
-  output:
-    postgres_dump_archive: "{{ _.postgres_dump_archive }}"
-    
-  tasks:
+output:
+  - postgres_dump_archive: '{{ ctx().postgres_dump_archive }}'
 
-    main:
-      action: std.noop
-      on-success:
-        - read_connection: "{{ _.date }}"
-        - date: "{{ not _.date }}"
-    
-    date:
-      action: core.local
-      input:
-        cmd: "date +%Y%m%d_%H%M%S"
-      publish:
-        date: "{{ task('date').result.stdout }}"
-      on-success:
-        - read_connection
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: '{{ succeeded() and (ctx().date) }}'
+        do:
+          - read_connection
+      - when: '{{ succeeded() and (not ctx().date) }}'
+        do:
+          - date
 
-    read_connection:
-      action: core.local
-      input:
-        cmd: "grep -E '^connection' {{ _.mistral_config }}"
-      publish:
-        postgres_connection: "{{ task('read_connection').result.stdout.split(' ')[2] }}"
-        postgres_dump_file: "{{ _.path }}/postgres_dump_{{ _.date }}.sql"
-        postgres_dump_archive: "{{ _.path }}/postgres_dump_{{ _.date }}.sql.gz"
-      on-success:
-        - mkdir_path
+  date:
+    action: core.local
+    input:
+      cmd: "date +%Y%m%d_%H%M%S"
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - date: '{{ result().stdout }}'
+        do:
+          - read_connection
 
-    mkdir_path:
-      action: core.local_sudo
-      input:
-        cmd: "mkdir -p '{{ _.path }}'"
-      on-success:
-        - postgres_backup
-        
-    postgres_backup:
-      action: core.local_sudo
-      input:
-        cmd: "pg_dump -f '{{ _.postgres_dump_file }}' '{{ _.postgres_connection }}'"
-      on-success:
-        - postgres_compress
+  read_connection:
+    action: core.local
+    input:
+      cmd: "grep -E '^connection' {{ ctx().mistral_config }}"
+    next:
+      - when: '{{ succeeded() }}'
+        publish:
+          - postgres_connection: "{{ result().stdout.split(' ')[2] }}"
+          - postgres_dump_archive: '{{ ctx().path }}/postgres_dump_{{ ctx().date }}.sql.gz'
+        do:
+          - mkdir_path
 
-    postgres_compress:
-      action: core.local_sudo
-      input:
-        cmd: "gzip '{{ _.postgres_dump_file }}'"
-      on-success:
-        - postgres_delete_old_files
+  mkdir_path:
+    action: core.local_sudo
+    input:
+      cmd: "mkdir -p '{{ ctx().path }}'"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - postgres_backup
 
-    postgres_delete_old_files:
-      action: core.local_sudo
-      input:
-        cwd: "{{ _.path }}"
-        cmd: "find . -name 'postgres_dump_*' -mtime {{ _.retention_days }} | xargs --no-run-if-empty rm"
-    
+  postgres_backup:
+    action: core.local_sudo
+    input:
+      cmd: "pg_dump --compress=9 -f '{{ ctx().postgres_dump_archive }}' '{{ ctx().postgres_connection }}'"
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - postgres_delete_old_files
+
+  postgres_delete_old_files:
+    action: core.local_sudo
+    input:
+      cwd: '{{ ctx().path }}'
+      cmd: "find . -name 'postgres_dump_*' -mtime {{ ctx().retention_days }} | xargs --no-run-if-empty rm"

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
     - postgresql
     - mongo
     - mongodb
-version: 0.1.1
+version: 1.0.0
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION

* Migrated from Mistral -> Orquesta  
* Added compression-in-place instead of dumping to a file/directory then running gzip.
  This reduces the required disk space to execute backups, because we don't have to store the intermediate uncompress data.
* Added `--quiet` to the `mongodump` command, so that progress bars don't litter the `stdout` of the action execution.