### PR TITLE
Backup timeout override

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 * Fixed issue with full_backup workflow that if only 1 of the methods failed
   it would still exit successful.
 
-  Contributed by Bradley Bishop (@nmaludy Encore Technologies)
+  Contributed by Bradley Bishop (Encore Technologies)
 
 ## v1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,20 +1,28 @@
 # Change Log
 
+## v1.0.1
+
+* Added backup.timeout key value look up for backup_timeout param
+* Fixed issue with full_backup workflow that if only 1 of the methods failed
+  it would still exit successful.
+
+  Contributed by Bradley Bishop (@nmaludy Encore Technologies)
+
 ## v1.0.0
 
 * Migrated from Mistral -> Orquesta (Feature)
-  
+
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
-  
+
 * Added compression-in-place instead of dumping to a file/directory then running gzip.
   This reduces the required disk space to execute backups, because we don't have to store
   the intermediate uncompress data. (Feature)
-  
+
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
 
 * Added `--quiet` to the `mongodump` command, so that progress bars don't litter the `stdout`
   of the action execution. (Bugfix)
-  
+
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
 
 ## v0.1.2

--- a/actions/full_backup.yaml
+++ b/actions/full_backup.yaml
@@ -25,5 +25,4 @@ parameters:
     default: "{{ st2kv.system.backup.retention_days | string | default('+14', true) }}"
   backup_timeout:
     type: integer
-    default: 600
-    
+    default: "{{ st2kv.system.backup.timeout | int | default(600, true) }}"

--- a/actions/full_backup.yaml
+++ b/actions/full_backup.yaml
@@ -25,4 +25,5 @@ parameters:
     default: "{{ st2kv.system.backup.retention_days | string | default('+14', true) }}"
   backup_timeout:
     type: integer
+    # We need the | int here because if the key doesn't exit it returns and empty string
     default: "{{ st2kv.system.backup.timeout | int | default(600, true) }}"

--- a/actions/workflows/full_backup.yaml
+++ b/actions/workflows/full_backup.yaml
@@ -9,6 +9,10 @@ input:
   - retention_days
   - backup_timeout
 
+vars:
+  - mongo_backup_success: false
+  - postgres_backup_success: false
+
 output:
   - mongodb_dump_archive: '{{ ctx().mongodb_dump_archive }}'
   - postgres_dump_archive: '{{ ctx().postgres_dump_archive }}'
@@ -36,7 +40,9 @@ tasks:
       retention_days: '{{ ctx().retention_days }}'
       backup_timeout: '{{ ctx().backup_timeout }}'
     next:
-      - publish:
+      - when: "{{ succeeded() }}"
+        publish:
+          - mongo_backup_success: true
           - mongodb_dump_archive: '{{ result().output.mongodb_dump_archive }}'
         do:
           - end
@@ -50,7 +56,9 @@ tasks:
       retention_days: '{{ ctx().retention_days }}'
       backup_timeout: '{{ ctx().backup_timeout }}'
     next:
-      - publish:
+      - when: "{{ succeeded() }}"
+        publish:
+          - postgres_backup_success: true
           - postgres_dump_archive: '{{ result().output.postgres_dump_archive }}'
         do:
           - end
@@ -58,3 +66,10 @@ tasks:
   end:
     action: core.noop
     join: all
+    next:
+      - when: "{{ succeeded() and (ctx().mongo_backup_success and ctx().postgres_backup_success) }}"
+        do:
+          - noop
+      - when: "{{ succeeded() and (not ctx().mongo_backup_success or not ctx().postgres_backup_success) }}"
+        do:
+          - fail

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,13 +2,13 @@
 ref: backups
 name: backups
 description: Pack to backup StackStorm databases
-keywords: 
+keywords:
     - backup
     - database
     - postgres
     - postgresql
     - mongo
     - mongodb
-version: 1.0.0
+version: 1.0.1
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION
Added backup.timeout key value lookup with same default value. Fixed issue where failed workflow was exiting with success.