### PR TITLE
Backup cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v2-dependency-cache-py27-{{ checksum "requirements.txt" }}
       - run:
           name: Download dependencies
           command: |
@@ -28,7 +28,7 @@ jobs:
           name: Run tests (Python 2.7)
           command: ~/ci/.circle/test
       - save_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v2-dependency-cache-py27-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
             - ~/.apt-cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v1.0.2
+
+* Fixed issue that if backups failed or timeed out then the old backups were not cleaned
+  up causing disks to fill.
+
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## v1.0.1
 
 * Added backup.timeout key value look up for backup_timeout param

--- a/actions/workflows/mongodb_backup.yaml
+++ b/actions/workflows/mongodb_backup.yaml
@@ -9,6 +9,9 @@ input:
   - retention_days
   - backup_timeout
 
+vars:
+  - run_success: true
+
 output:
   - mongodb_dump_archive: '{{ ctx().mongodb_dump_archive }}'
 
@@ -55,6 +58,8 @@ tasks:
         do:
           - mongodb_backup_with_auth
 
+  # Even though the action might timeout the back up eventually succeeds so we still want to
+  # remove the old backups to prevent the disk space from filling up.
   mongodb_backup:
     action: core.local_sudo
     input:
@@ -65,7 +70,14 @@ tasks:
       - when: '{{ succeeded() }}'
         do:
           - mongodb_delete_old_files
+      - when: '{{ failed() }}'
+        publish:
+          - run_success: false
+        do:
+          - mongodb_delete_old_files
 
+  # Even though the action might timeout the back up eventually succeeds so we still want to
+  # remove the old backups to prevent the disk space from filling up.
   mongodb_backup_with_auth:
     action: core.local_sudo
     input:
@@ -76,9 +88,21 @@ tasks:
       - when: '{{ succeeded() }}'
         do:
           - mongodb_delete_old_files
+      - when: '{{ failed() }}'
+        publish:
+          - run_success: false
+        do:
+          - mongodb_delete_old_files
 
   mongodb_delete_old_files:
     action: core.local_sudo
     input:
       cwd: '{{ ctx().path }}'
       cmd: "find . -name 'mongodb_dump_*' -mtime {{ ctx().retention_days }} | xargs --no-run-if-empty rm"
+    next:
+      - when: "{{ succeeded() and (ctx().run_success) }}"
+        do:
+          - noop
+      - when: "{{ succeeded() and (not ctx().run_success) }}"
+        do:
+          - fail

--- a/actions/workflows/postgres_backup.yaml
+++ b/actions/workflows/postgres_backup.yaml
@@ -8,6 +8,9 @@ input:
   - retention_days
   - backup_timeout
 
+vars:
+  - run_success: true
+
 output:
   - postgres_dump_archive: '{{ ctx().postgres_dump_archive }}'
 
@@ -54,6 +57,8 @@ tasks:
         do:
           - postgres_backup
 
+  # Even though the action might timeout the back up eventually succeeds so we still want to
+  # remove the old backups to prevent the disk space from filling up.
   postgres_backup:
     action: core.local_sudo
     input:
@@ -63,9 +68,21 @@ tasks:
       - when: '{{ succeeded() }}'
         do:
           - postgres_delete_old_files
+      - when: '{{ failed() }}'
+        publish:
+          - run_success: false
+        do:
+          - postgres_delete_old_files
 
   postgres_delete_old_files:
     action: core.local_sudo
     input:
       cwd: '{{ ctx().path }}'
       cmd: "find . -name 'postgres_dump_*' -mtime {{ ctx().retention_days }} | xargs --no-run-if-empty rm"
+    next:
+      - when: "{{ succeeded() and (ctx().run_success) }}"
+        do:
+          - noop
+      - when: "{{ succeeded() and (not ctx().run_success) }}"
+        do:
+          - fail

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - postgresql
   - mongo
   - mongodb
-version: 1.0.1
+version: 1.0.2
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
Fixed issue where if the backup times out or fails then the previous backups are not removed causing disks to fill up. When the action times out the back up eventually succeeds meaning all the normal disk space is still getting used.

Before:
![Screen Shot 2020-03-02 at 10 53 54 AM](https://user-images.githubusercontent.com/15911425/75695455-12d4fa80-5c78-11ea-9c97-989e42f039e9.png)

After:
![Screen Shot 2020-03-02 at 11 19 25 AM](https://user-images.githubusercontent.com/15911425/75695470-1b2d3580-5c78-11ea-85ce-ee7f65cbf70f.png)
