### PR TITLE
Join task not being executed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.0.3
+
+* Fixed issues with join task not being executed when items fail.
+
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## v1.0.2
 
 * Fixed issue that if backups failed or timeed out then the old backups were not cleaned

--- a/actions/workflows/full_backup.yaml
+++ b/actions/workflows/full_backup.yaml
@@ -40,9 +40,9 @@ tasks:
       retention_days: '{{ ctx().retention_days }}'
       backup_timeout: '{{ ctx().backup_timeout }}'
     next:
-      - when: "{{ succeeded() }}"
+      - when: "{{ completed() }}"
         publish:
-          - mongo_backup_success: true
+          - mongo_backup_success: "{{ true if succeeded() else false }}"
           - mongodb_dump_archive: '{{ result().output.mongodb_dump_archive }}'
         do:
           - end
@@ -56,9 +56,9 @@ tasks:
       retention_days: '{{ ctx().retention_days }}'
       backup_timeout: '{{ ctx().backup_timeout }}'
     next:
-      - when: "{{ succeeded() }}"
+      - when: "{{ completed() }}"
         publish:
-          - postgres_backup_success: true
+          - postgres_backup_success: "{{ true if succeeded() else false }}"
           - postgres_dump_archive: '{{ result().output.postgres_dump_archive }}'
         do:
           - end

--- a/actions/workflows/mongodb_backup.yaml
+++ b/actions/workflows/mongodb_backup.yaml
@@ -10,6 +10,7 @@ input:
   - backup_timeout
 
 vars:
+  - mongodb_dump_archive: ""
   - run_success: true
 
 output:

--- a/actions/workflows/postgres_backup.yaml
+++ b/actions/workflows/postgres_backup.yaml
@@ -9,6 +9,7 @@ input:
   - backup_timeout
 
 vars:
+  - postgres_dump_archive: ""
   - run_success: true
 
 output:

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - postgresql
   - mongo
   - mongodb
-version: 1.0.2
+version: 1.0.3
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
Updated workflows so that the join is always executed. No other remediation was needed as there are not many nested workflows

Before (join `end` task not executed):
![Screen Shot 2020-03-09 at 3 55 43 PM](https://user-images.githubusercontent.com/15911425/76321418-6074e700-62b8-11ea-8f71-63b93254df62.png)

After:
![Screen Shot 2020-03-09 at 4 01 39 PM](https://user-images.githubusercontent.com/15911425/76321458-71255d00-62b8-11ea-9248-6c187c54c066.png)
