### PR TITLE
Force release 1.0.5 to include hotfix for backups.full_backup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.5
+
+* Forced release to included hotfix for `backups.full_backup`
+
 ## v1.0.4
 
 * Added mongodb_host option to backup remote MongoDB database. Defaults to '127.0.0.1'

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - postgresql
   - mongo
   - mongodb
-version: 1.0.4
+version: 1.0.5
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
Somehow this commit: https://github.com/StackStorm-Exchange/stackstorm-backups/pull/13/commits/cd41479e99666f05e7427acfa9ef31581489ad7f

Didn't get included in the 1.0.4 tag, so backups are failing for us internally.